### PR TITLE
Update autocomplete.js

### DIFF
--- a/autocomplete.js
+++ b/autocomplete.js
@@ -12,7 +12,7 @@ function enableAutocomplete()
         numItems = snapshot.snapshotLength - 1;
 
     for (var i = numItems; i >= 0; i--)
-        snapshot.snapshotItem(i).nodeValue = 'on';
+        snapshot.snapshotItem(i).value = 'on';
 }
 
 // The password manager code checks for "autocomplete=off" in a callback


### PR DESCRIPTION
This warning shows up in the chrome developer console every time I open a page.

'Attr.nodeValue' is deprecated. Please use 'value' instead.

This should fix that issue.
