### PR TITLE
updated to fix chrome warning message on nodeValue being deprecated

### DIFF
--- a/autocomplete.js
+++ b/autocomplete.js
@@ -7,12 +7,14 @@
 
 function enableAutocomplete()
 {
+    'use strict';
     var snapshot = document.evaluate('//@autocomplete',
         document, null, XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE, null),
         numItems = snapshot.snapshotLength - 1;
 
-    for (var i = numItems; i >= 0; i--)
-        snapshot.snapshotItem(i).nodeValue = 'on';
+    for (var i = numItems; i >= 0; i--) {
+        snapshot.snapshotItem(i).value = 'on';
+    }
 }
 
 // The password manager code checks for "autocomplete=off" in a callback


### PR DESCRIPTION
Chrome has been giving me a warning when this is on because nodeValue is deprecated. I also modified the file based on some javascript linting.
